### PR TITLE
fix(git): remove trailing space from upstream icons

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -492,19 +492,19 @@ func (g *Git) getUpstreamIcon() string {
 		Icon    properties.Property
 		Default string
 	}{
-		"github":           {GithubIcon, "\uF408 "},
-		"gitlab":           {GitlabIcon, "\uF296 "},
-		"bitbucket":        {BitbucketIcon, "\uF171 "},
-		"dev.azure.com":    {AzureDevOpsIcon, "\uEBE8 "},
-		"visualstudio.com": {AzureDevOpsIcon, "\uEBE8 "},
-		"codecommit":       {CodeCommit, "\uF270 "},
+		"github":           {GithubIcon, "\uF408"},
+		"gitlab":           {GitlabIcon, "\uF296"},
+		"bitbucket":        {BitbucketIcon, "\uF171"},
+		"dev.azure.com":    {AzureDevOpsIcon, "\uEBE8"},
+		"visualstudio.com": {AzureDevOpsIcon, "\uEBE8"},
+		"codecommit":       {CodeCommit, "\uF270"},
 	}
 	for key, value := range defaults {
 		if strings.Contains(g.UpstreamURL, key) {
 			return g.props.GetString(value.Icon, value.Default)
 		}
 	}
-	return g.props.GetString(GitIcon, "\uE5FB ")
+	return g.props.GetString(GitIcon, "\uE5FB")
 }
 
 func (g *Git) setGitStatus() {

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -183,7 +183,7 @@ func TestEnabledInBareRepo(t *testing.T) {
 			FetchRemote:     true,
 			Remote:          "origin",
 			RemoteURL:       "git@github.com:JanDeDobbeleer/oh-my-posh.git",
-			ExpectedRemote:  "\uf408 ",
+			ExpectedRemote:  "\uf408",
 		},
 	}
 	for _, tc := range cases {

--- a/website/docs/segments/git.mdx
+++ b/website/docs/segments/git.mdx
@@ -111,12 +111,12 @@ You can set the following properties to `true` to enable fetching additional inf
 
 | Name                | Type                | Description                                                                                                                                                                  |
 | ------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `github_icon`       | `string`            | icon/text to display when the upstream is Github - defaults to `\uF408 `                                                                                                     |
-| `gitlab_icon`       | `string`            | icon/text to display when the upstream is Gitlab - defaults to `\uF296 `                                                                                                     |
-| `bitbucket_icon`    | `string`            | icon/text to display when the upstream is Bitbucket - defaults to `\uF171 `                                                                                                  |
-| `azure_devops_icon` | `string`            | icon/text to display when the upstream is Azure DevOps - defaults to `\uEBE8 `                                                                                               |
-| `codecommit_icon`   | `string`            | icon/text to display when the upstream is AWS CodeCommit - defaults to `\uF270 `                                                                                             |
-| `git_icon`          | `string`            | icon/text to display when the upstream is not known/mapped - defaults to `\uE5FB `                                                                                           |
+| `github_icon`       | `string`            | icon/text to display when the upstream is Github - defaults to `\uF408`                                                                                                      |
+| `gitlab_icon`       | `string`            | icon/text to display when the upstream is Gitlab - defaults to `\uF296`                                                                                                      |
+| `bitbucket_icon`    | `string`            | icon/text to display when the upstream is Bitbucket - defaults to `\uF171`                                                                                                   |
+| `azure_devops_icon` | `string`            | icon/text to display when the upstream is Azure DevOps - defaults to `\uEBE8`                                                                                                |
+| `codecommit_icon`   | `string`            | icon/text to display when the upstream is AWS CodeCommit - defaults to `\uF270`                                                                                              |
+| `git_icon`          | `string`            | icon/text to display when the upstream is not known/mapped - defaults to `\uE5FB`                                                                                            |
 | `upstream_icons`    | `map[string]string` | a key, value map representing the remote URL (or a part of that URL) and icon to use in case the upstream URL contains the key. These get precedence over the standard icons |
 
 ## Template ([info][templates])
@@ -157,7 +157,7 @@ You can set the following properties to `true` to enable fetching additional inf
 | `.Rebase`        | `boolean` | true when in a rebase                                                                                                            |
 | `.CherryPick`    | `boolean` | true when in a cherry pick                                                                                                       |
 | `.Revert`        | `boolean` | true when in a revert                                                                                                            |
-| `.LatestTag`     | `string`  | the latest tag name                                                                                                       |
+| `.LatestTag`     | `string`  | the latest tag name                                                                                                              |
 
 ### Status
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Removed the spaces as discussed in #4774.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
